### PR TITLE
client(docs): update copyright year and add personal site link

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Laxman Goud
+Copyright (c) 2026 Laxman Goud
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/client/src/components/Footer.jsx
+++ b/client/src/components/Footer.jsx
@@ -51,7 +51,7 @@ const Footer = () => {
 
             {/* Copyright */}
             <p className='py-4 text-center text-sm md:text-base text-gray-500/80'>
-                Copyright 2025 QuickBlog Laxman – All Rights Reserved.
+                Copyright 2026  <a href="https://laxman-thedev.vercel.app" className='underline' >Laxman</a> – All Rights Reserved.
             </p>
         </div>
     )


### PR DESCRIPTION
### What’s changed
- Updated copyright year to 2026 in the LICENSE file
- Added personal portfolio link to the footer copyright text

### Why
- Keeps legal and footer information up to date
- Provides an easy way to access the author’s personal website

### Type of change
- Documentation / maintenance update
