### PR TITLE
docs: update demo section in README with live link

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,12 +174,9 @@ npm run dev
 
 ---
 
-## 🚀 Demo (Live Links)
+## 🚀 Demo (Live Link)
 
-* **Client:** *Add Vercel client URL here*
-* **Server:** *Add Vercel server URL here*
-
-*(Update links after deployment)*
+* **Demo:** *https://quick-blog-platform.vercel.app*
 
 ---
 


### PR DESCRIPTION
This pull request updates the demo section in the `README.md` file to provide a direct link to the deployed application.

- Documentation update:
  * Changed the demo section to include a single "Demo" link pointing to the live application at `https://quick-blog-platform.vercel.app`, replacing the previous placeholders for client and server URLs.